### PR TITLE
feat: implement reusable ErrorMessage component for social login errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,4 +95,5 @@ resources/js/
 - **NO hardcoded strings** in templates - every string visible to users must use `$t('Translation Key')`
 - **Dynamic placeholders** use `:placeholder="$t('Placeholder text')"` instead of `placeholder="Static text"`  
 - **Add Portuguese translations** to `/lang/pt_BR.json` for all new translation keys
+- **NEVER create en.json** - English uses translation keys as fallback values
 - **Test language switching** to ensure all text updates correctly

--- a/app/Http/Controllers/SocialAuthController.php
+++ b/app/Http/Controllers/SocialAuthController.php
@@ -40,7 +40,7 @@ class SocialAuthController extends Controller
             ]);
         } catch (Exception $e) {
             return redirect('/login')->withErrors([
-                'social' => 'Authentication failed. Please try again.',
+                'social' => __('Authentication failed. Please try again.'),
             ]);
         }
     }
@@ -64,7 +64,7 @@ class SocialAuthController extends Controller
         try {
             $disconnectAction->execute($user, $provider);
 
-            return back()->with('success', ucfirst($provider).' account disconnected successfully.');
+            return back()->with('success', __(':provider account disconnected successfully.', ['provider' => ucfirst($provider)]));
         } catch (SocialAuthException $e) {
             return back()->withErrors([
                 'social' => $e->getMessage(),

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -129,5 +129,7 @@
     "Theme": "Tema",
     "Light": "Claro",
     "Dark": "Escuro",
-    "Auto": "Auto"
+    "Auto": "Auto",
+    "Authentication failed. Please try again.": "Falha na autenticação. Tente novamente.",
+    ":provider account disconnected successfully.": "Conta :provider desconectada com sucesso."
 }

--- a/resources/js/components/ui/ErrorMessage.vue
+++ b/resources/js/components/ui/ErrorMessage.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { usePage } from '@inertiajs/vue3';
+import {
+    AlertCircle,
+    AlertTriangle,
+    CheckCircle,
+    Info,
+    type LucideIcon,
+} from 'lucide-vue-next';
+import { computed, type Component } from 'vue';
+
+interface Props {
+    field: string;
+    variant?: 'success' | 'info' | 'warning' | 'error' | 'default';
+    appearance?: 'filled' | 'bordered' | 'outlined';
+    icon?: Component;
+    hideIcon?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    variant: 'error',
+    appearance: 'filled',
+    hideIcon: false,
+});
+
+const page = usePage();
+const message = computed(() => page.props.errors?.[props.field]);
+
+const defaultIcons: Record<string, LucideIcon> = {
+    success: CheckCircle,
+    info: Info,
+    warning: AlertTriangle,
+    error: AlertCircle,
+    default: Info,
+};
+
+const currentIcon = computed(() => {
+    if (props.hideIcon) return null;
+    if (props.icon) return props.icon;
+    return defaultIcons[props.variant];
+});
+
+const baseVariant = computed(() => {
+    // Map our variants to shadcn variants
+    if (props.variant === 'error') return 'destructive';
+    return 'default';
+});
+
+const variantStyles = {
+    success: {
+        filled: 'border-green-500 bg-green-500 text-white [&>svg]:text-white *:data-[slot=alert-description]:text-white',
+        bordered:
+            'bg-green-50 text-green-800 border-green-200 dark:bg-green-950 dark:text-green-200 [&>svg]:text-green-800 dark:[&>svg]:text-green-200',
+        outlined:
+            'bg-transparent border-2 border-green-500 text-green-600 dark:text-green-400 [&>svg]:text-green-600 dark:[&>svg]:text-green-400',
+    },
+    info: {
+        filled: 'border-blue-500 bg-blue-500 text-white [&>svg]:text-white *:data-[slot=alert-description]:text-white',
+        bordered:
+            'bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-950 dark:text-blue-200 [&>svg]:text-blue-800 dark:[&>svg]:text-blue-200',
+        outlined:
+            'bg-transparent border-2 border-blue-500 text-blue-600 dark:text-blue-400 [&>svg]:text-blue-600 dark:[&>svg]:text-blue-400',
+    },
+    warning: {
+        filled: 'border-yellow-500 bg-yellow-500 text-black [&>svg]:text-black *:data-[slot=alert-description]:text-black',
+        bordered:
+            'bg-yellow-50 text-yellow-800 border-yellow-200 dark:bg-yellow-950 dark:text-yellow-200 [&>svg]:text-yellow-800 dark:[&>svg]:text-yellow-200',
+        outlined:
+            'bg-transparent border-2 border-yellow-500 text-yellow-600 dark:text-yellow-400 [&>svg]:text-yellow-600 dark:[&>svg]:text-yellow-400',
+    },
+    error: {
+        filled: 'border-red-500 bg-red-500 text-white [&>svg]:text-white *:data-[slot=alert-description]:text-white',
+        bordered:
+            'bg-red-50 text-red-800 border-red-200 dark:bg-red-950 dark:text-red-200 [&>svg]:text-red-800 dark:[&>svg]:text-red-200',
+        outlined:
+            'bg-transparent border-2 border-red-500 text-red-600 dark:text-red-400 [&>svg]:text-red-600 dark:[&>svg]:text-red-400',
+    },
+    default: {
+        filled: '',
+        bordered: '',
+        outlined: 'bg-transparent border-2',
+    },
+};
+
+const customClasses = computed(() => {
+    return variantStyles[props.variant]?.[props.appearance] || '';
+});
+</script>
+
+<template>
+    <Alert
+        v-if="message"
+        :variant="baseVariant"
+        :class="customClasses"
+        class="mb-4"
+    >
+        <component :is="currentIcon" v-if="currentIcon" class="h-4 w-4" />
+        <AlertDescription>
+            {{ message }}
+        </AlertDescription>
+    </Alert>
+</template>

--- a/resources/js/components/ui/alert/Alert.vue
+++ b/resources/js/components/ui/alert/Alert.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils';
+import type { HTMLAttributes } from 'vue';
+import type { AlertVariants } from '.';
+import { alertVariants } from '.';
+
+const props = defineProps<{
+    class?: HTMLAttributes['class'];
+    variant?: AlertVariants['variant'];
+}>();
+</script>
+
+<template>
+    <div
+        data-slot="alert"
+        :class="cn(alertVariants({ variant }), props.class)"
+        role="alert"
+    >
+        <slot />
+    </div>
+</template>

--- a/resources/js/components/ui/alert/AlertDescription.vue
+++ b/resources/js/components/ui/alert/AlertDescription.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils';
+import type { HTMLAttributes } from 'vue';
+
+const props = defineProps<{
+    class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+    <div
+        data-slot="alert-description"
+        :class="
+            cn(
+                'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+                props.class,
+            )
+        "
+    >
+        <slot />
+    </div>
+</template>

--- a/resources/js/components/ui/alert/AlertTitle.vue
+++ b/resources/js/components/ui/alert/AlertTitle.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils';
+import type { HTMLAttributes } from 'vue';
+
+const props = defineProps<{
+    class?: HTMLAttributes['class'];
+}>();
+</script>
+
+<template>
+    <div
+        data-slot="alert-title"
+        :class="
+            cn(
+                'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight',
+                props.class,
+            )
+        "
+    >
+        <slot />
+    </div>
+</template>

--- a/resources/js/components/ui/alert/index.ts
+++ b/resources/js/components/ui/alert/index.ts
@@ -1,0 +1,24 @@
+import type { VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
+
+export { default as Alert } from './Alert.vue';
+export { default as AlertDescription } from './AlertDescription.vue';
+export { default as AlertTitle } from './AlertTitle.vue';
+
+export const alertVariants = cva(
+    'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+    {
+        variants: {
+            variant: {
+                default: 'bg-card text-card-foreground',
+                destructive:
+                    'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+            },
+        },
+        defaultVariants: {
+            variant: 'default',
+        },
+    },
+);
+
+export type AlertVariants = VariantProps<typeof alertVariants>;

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import ErrorMessage from '@/components/ui/ErrorMessage.vue';
 import FormControl from '@/components/ui/form/FormControl.vue';
 import FormField from '@/components/ui/form/FormField.vue';
 import FormItem from '@/components/ui/form/FormItem.vue';
@@ -76,6 +77,9 @@ const onSubmit = async () => {
         <div v-if="status" class="mb-4 text-sm font-medium text-green-600">
             {{ status }}
         </div>
+
+        <!-- Social Login Error -->
+        <ErrorMessage field="social" variant="error" />
 
         <!-- Social Login Section -->
         <div

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Button } from '@/components/ui/button';
+import ErrorMessage from '@/components/ui/ErrorMessage.vue';
 import FormControl from '@/components/ui/form/FormControl.vue';
 import FormField from '@/components/ui/form/FormField.vue';
 import FormItem from '@/components/ui/form/FormItem.vue';
@@ -64,6 +65,9 @@ const onSubmit = form.handleSubmit((values: RegisterFormData) => {
                 {{ $t('Sign up for Sauce Base to start building your SaaS') }}
             </p>
         </div>
+
+        <!-- Social Login Error -->
+        <ErrorMessage field="social" variant="error" />
 
         <!-- Social Login Section -->
         <div
@@ -135,13 +139,13 @@ const onSubmit = form.handleSubmit((values: RegisterFormData) => {
 
             <FormField name="password" v-slot="{ componentField }">
                 <FormItem>
-                    <FormLabel :error="inertiaForm.errors.password"
-                        >Password</FormLabel
-                    >
+                    <FormLabel :error="inertiaForm.errors.password">{{
+                        $t('Password')
+                    }}</FormLabel>
                     <FormControl>
                         <PasswordInput
                             v-bind="componentField"
-                            placeholder="Create a password"
+                            :placeholder="$t('Create a password')"
                             autocomplete="new-password"
                             :error="inertiaForm.errors.password"
                         />
@@ -152,13 +156,14 @@ const onSubmit = form.handleSubmit((values: RegisterFormData) => {
 
             <FormField name="password_confirmation" v-slot="{ componentField }">
                 <FormItem>
-                    <FormLabel :error="inertiaForm.errors.password_confirmation"
-                        >Confirm Password</FormLabel
+                    <FormLabel
+                        :error="inertiaForm.errors.password_confirmation"
+                        >{{ $t('Confirm Password') }}</FormLabel
                     >
                     <FormControl>
                         <PasswordInput
                             v-bind="componentField"
-                            placeholder="Confirm your password"
+                            :placeholder="$t('Confirm your password')"
                             autocomplete="new-password"
                             :error="inertiaForm.errors.password_confirmation"
                         />
@@ -176,7 +181,7 @@ const onSubmit = form.handleSubmit((values: RegisterFormData) => {
                     :href="route('login')"
                     class="text-sm text-gray-600 underline hover:text-gray-900 focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-hidden dark:text-gray-400 dark:hover:text-gray-100 dark:focus:ring-offset-gray-800"
                 >
-                    Already registered?
+                    {{ $t('Already registered?') }}
                 </Link>
 
                 <Button
@@ -184,7 +189,7 @@ const onSubmit = form.handleSubmit((values: RegisterFormData) => {
                     :class="{ 'opacity-25': inertiaForm.processing }"
                     :disabled="inertiaForm.processing"
                 >
-                    Register
+                    {{ $t('Register') }}
                 </Button>
             </div>
         </form>


### PR DESCRIPTION
## Summary
- Created reusable ErrorMessage component with multiple variants and appearances
- Added i18n support for social authentication error messages
- Refactored Login and Register pages to eliminate code duplication
- Updated documentation guidelines for internationalization

## Test plan
- [x] Verify social login errors display with proper styling (red background, white text)
- [x] Test error messages in both English and Portuguese
- [x] Confirm ErrorMessage component works with different variants (success, info, warning, error)
- [x] Validate no regressions in Login/Register page functionality