### PR TITLE
Fix GitHub Socialite provider name fallback handling

### DIFF
--- a/app/Actions/LinkSocialAccountAction.php
+++ b/app/Actions/LinkSocialAccountAction.php
@@ -63,7 +63,7 @@ class LinkSocialAccountAction
     private function createNewUser(object $socialUser, ?string $avatarUrl): User
     {
         return User::create([
-            'name' => $socialUser->getName(),
+            'name' => $socialUser->getName() ?: $socialUser->getNickname(),
             'email' => $socialUser->getEmail(),
             'email_verified_at' => now(),
             'password' => bcrypt(str()->random(32)), // Random password
@@ -85,9 +85,11 @@ class LinkSocialAccountAction
 
     private function validateSocialUser(object $socialUser): void
     {
-        if (! $socialUser->getEmail() ||
+        if (
+            ! $socialUser->getEmail() ||
             ! $socialUser->getId() ||
-            ! filter_var($socialUser->getEmail(), FILTER_VALIDATE_EMAIL)) {
+            ! filter_var($socialUser->getEmail(), FILTER_VALIDATE_EMAIL)
+        ) {
             throw SocialAuthException::invalidSocialUser();
         }
     }


### PR DESCRIPTION
## Summary
- Implements fallback handling for GitHub users with no public name
- Uses nickname as fallback when name is not available from GitHub API
- Prevents authentication failures for users without configured names

## Changes
- Updated `LinkSocialAccountAction.php` to handle null name values gracefully
- Added fallback chain: `getName()` → `getNickname()`

## Testing
- Tested with GitHub accounts without public names
- Verified graceful fallback behavior
- Ensured no database constraint violations

Fixes #79