### PR TITLE
feat(blog): add PostPolicy and CategoryPolicy for managing blog post …

### DIFF
--- a/modules/Blog/app/Policies/BlogPolicy.php
+++ b/modules/Blog/app/Policies/BlogPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Blog\Policies;
+
+use App\Models\User;
+use Modules\Blog\Models\Post;
+
+class PostPolicy
+{
+    public function create(User $user): bool
+    {
+        return ! is_demo_mode();
+    }
+
+    public function update(User $user, Post $post): bool
+    {
+        return ! is_demo_mode();
+    }
+
+    public function delete(User $user, Post $post): bool
+    {
+        return ! is_demo_mode();
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return ! is_demo_mode();
+    }
+}

--- a/modules/Blog/app/Policies/CategoryPolicy.php
+++ b/modules/Blog/app/Policies/CategoryPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Blog\Policies;
+
+use App\Models\User;
+use Modules\Blog\Models\Category;
+
+class CategoryPolicy
+{
+    public function create(User $user): bool
+    {
+        return ! is_demo_mode();
+    }
+
+    public function update(User $user, Category $category): bool
+    {
+        return ! is_demo_mode();
+    }
+
+    public function delete(User $user, Category $category): bool
+    {
+        return ! is_demo_mode();
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return ! is_demo_mode();
+    }
+}


### PR DESCRIPTION
This pull request introduces new policy classes for the Blog module, adding authorization logic to restrict certain actions when the application is in demo mode. The policies ensure that users cannot create, update, or delete blog posts or categories if demo mode is enabled.

Authorization policies for demo mode:

* Added `PostPolicy` in `modules/Blog/app/Policies/BlogPolicy.php` to restrict creating, updating, and deleting blog posts when demo mode is active.
* Added `CategoryPolicy` in `modules/Blog/app/Policies/CategoryPolicy.php` to restrict creating, updating, and deleting blog categories when demo mode is active.