### PR TITLE
feat(modules): add Blog module status to modules_statuses.json

### DIFF
--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -5,5 +5,6 @@
     "Settings": true,
     "Roadmap": true,
     "Themes": true,
-    "Demo": true
+    "Demo": true,
+    "Blog": true
 }


### PR DESCRIPTION
This pull request introduces new policy classes for the Blog module, adding authorization logic to restrict certain actions when the application is in demo mode. The policies ensure that users cannot create, update, or delete blog posts or categories if demo mode is enabled.

Authorization policies for demo mode:

* Added `PostPolicy` in `modules/Blog/app/Policies/BlogPolicy.php` to restrict creating, updating, and deleting blog posts when demo mode is active.
* Added `CategoryPolicy` in `modules/Blog/app/Policies/CategoryPolicy.php` to restrict creating, updating, and deleting blog categories when demo mode is active.