### PR TITLE
Enhance StackCommand with npm install functionality and update tests

### DIFF
--- a/app/Console/Commands/SauceBase/StackCommand.php
+++ b/app/Console/Commands/SauceBase/StackCommand.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands\SauceBase;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
 
 class StackCommand extends Command
 {
@@ -119,8 +120,9 @@ class StackCommand extends Command
 
         $this->writeFrontendJson($framework, dev: true);
         $this->skipGeneratedFiles($framework);
+        $this->runNpmInstall();
 
-        $this->info("Framework set to {$framework} (dev mode). Run: npm install && npm run dev");
+        $this->info("Framework set to {$framework} (dev mode). Run: composer dev");
 
         return self::SUCCESS;
     }
@@ -395,6 +397,22 @@ class StackCommand extends Command
     {
         foreach ($this->generatedFiles($framework) as $file) {
             exec("git -C {$this->basePath} update-index --no-skip-worktree {$file} 2>/dev/null");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Node helpers
+    // -------------------------------------------------------------------------
+
+    protected function runNpmInstall(): void
+    {
+        $this->info('Running npm install...');
+        $process = new Process(['npm', 'install'], $this->basePath);
+        $process->setTimeout(300);
+        $process->run(fn ($_type, $buffer) => $this->output->write($buffer));
+
+        if (! $process->isSuccessful()) {
+            $this->warn('npm install failed. Run manually: npm install');
         }
     }
 

--- a/composer.lock
+++ b/composer.lock
@@ -3213,16 +3213,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.13.0",
+            "version": "v13.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "1daa6d3b4defe46976ccfa4fb0a7ab62717712a2"
+                "reference": "e60b1c817a9ef7da319e4007de6cfda5301a58c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/1daa6d3b4defe46976ccfa4fb0a7ab62717712a2",
-                "reference": "1daa6d3b4defe46976ccfa4fb0a7ab62717712a2",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/e60b1c817a9ef7da319e4007de6cfda5301a58c0",
+                "reference": "e60b1c817a9ef7da319e4007de6cfda5301a58c0",
                 "shasum": ""
             },
             "require": {
@@ -3433,7 +3433,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-06-02T14:28:17+00:00"
+            "time": "2026-06-04T18:46:35+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/package.json
+++ b/package.json
@@ -1,1 +1,16 @@
-{}
+{
+    "$schema": "https://www.schemastore.org/package.json",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "build": "vite build",
+        "dev": "vite"
+    },
+    "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "concurrently": "^9.0.1",
+        "laravel-vite-plugin": "^3.1",
+        "tailwindcss": "^4.0.0",
+        "vite": "^8.0.0"
+    }
+}

--- a/stubs/saucebase/recipes/basic/.github/workflows/release.yml
+++ b/stubs/saucebase/recipes/basic/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     release:
         uses: saucebase-dev/saucebase/.github/workflows/semantic-release.yml@main
         with:
-            version_file: 'module.json'
+            version_file: 'composer.json'
             version_file_path: '.version'
             prerelease: false
         secrets:

--- a/tests/Feature/StackCommandTest.php
+++ b/tests/Feature/StackCommandTest.php
@@ -38,11 +38,9 @@ class StackCommandTest extends TestCase
         exec("git -C {$this->tmpDir} commit -q -m 'initial' 2>/dev/null");
 
         $tmpDir = $this->tmpDir;
-        app()->bind(StackCommand::class, fn () => new StackCommand(
-            new Filesystem,
-            $tmpDir,
-            $tmpDir.'/resources/js',
-        ));
+        app()->bind(StackCommand::class, fn () => new class(new Filesystem, $tmpDir, $tmpDir.'/resources/js') extends StackCommand {
+            protected function runNpmInstall(): void {}
+        });
     }
 
     protected function tearDown(): void
@@ -95,6 +93,33 @@ class StackCommandTest extends TestCase
 
         $this->assertStringContainsString("import './react/app'", file_get_contents($this->tmpDir.'/resources/js/app.tsx'));
         $this->assertStringContainsString("import './react/ssr'", file_get_contents($this->tmpDir.'/resources/js/ssr.tsx'));
+    }
+
+    public function test_dev_mode_runs_npm_install(): void
+    {
+        $this->seedFakeStubs('vue');
+        $spy = (object) ['called' => false];
+
+        $tmpDir = $this->tmpDir;
+        app()->bind(StackCommand::class, function () use ($tmpDir, $spy) {
+            return new class(new Filesystem, $tmpDir, $tmpDir.'/resources/js', $spy) extends StackCommand {
+                private object $spy;
+
+                public function __construct(Filesystem $files, string $basePath, string $jsRoot, object $spy)
+                {
+                    parent::__construct($files, $basePath, $jsRoot);
+                    $this->spy = $spy;
+                }
+
+                protected function runNpmInstall(): void
+                {
+                    $this->spy->called = true;
+                }
+            };
+        });
+
+        $this->artisan('saucebase:stack vue --dev')->assertSuccessful();
+        $this->assertTrue($spy->called);
     }
 
     public function test_dev_mode_does_not_copy_source_files(): void

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,1 +1,18 @@
-export default {};
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.ts'],
+            refresh: true,
+        }),
+        tailwindcss(),
+    ],
+    server: {
+        watch: {
+            ignored: ['**/storage/framework/views/**'],
+        },
+    },
+});


### PR DESCRIPTION
This pull request introduces improvements to the development workflow for the `StackCommand` and sets up the frontend build tooling with Vite, Tailwind CSS, and related dependencies. The most significant changes are the automation of `npm install` during dev mode, enhancements to the test suite to accommodate this automation, and the addition of configuration files for the frontend stack.

**Development workflow automation:**

* The `StackCommand` now automatically runs `npm install` when setting the framework to dev mode, streamlining setup for developers. The user-facing message has been updated to reference `composer dev` instead of manual npm commands. (`app/Console/Commands/SauceBase/StackCommand.php`) [[1]](diffhunk://#diff-10403fd7c6be32419057ab58becba22b6b5b638c4a45c34b51dfd3a88061debeR123-R125) [[2]](diffhunk://#diff-10403fd7c6be32419057ab58becba22b6b5b638c4a45c34b51dfd3a88061debeR403-R418)
* Added a helper method `runNpmInstall()` to encapsulate the logic for running `npm install` and handling errors. (`app/Console/Commands/SauceBase/StackCommand.php`)

**Frontend tooling setup:**

* Added a `package.json` with scripts for building and running the frontend using Vite, and included dependencies for Tailwind CSS, Vite, and related plugins. (`package.json`)
* Replaced the placeholder `vite.config.js` with a full configuration integrating Laravel, Vite, and Tailwind CSS plugins, and set up file watching exclusions. (`vite.config.js`)

**Testing improvements:**

* Updated tests to mock out the `runNpmInstall()` method, preventing actual npm installs during tests. (`tests/Feature/StackCommandTest.php`)
* Added a new test to verify that `runNpmInstall()` is called when running dev mode, ensuring the automation works as intended. (`tests/Feature/StackCommandTest.php`)