### PR TITLE
Add canonical option to path repository in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,6 +156,7 @@
         {
             "type": "path",
             "url": "modules/*",
+            "canonical": false,
             "options": {
                 "symlink": true
             }


### PR DESCRIPTION
This pull request makes a small change to the `composer.json` file, updating the repository configuration for local modules. The change adds the `canonical: false` option to the repository definition, which helps Composer resolve dependencies more accurately when using local paths.