### PR TITLE
refactor: update module name handling to use lowercase for consistency

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -7,7 +7,7 @@ on:
             module:
                 required: true
                 type: string
-                description: 'StudlyCase module name, e.g. Billing'
+                description: 'LowerCase module name, e.g. billing'
             dependencies:
                 required: false
                 type: string
@@ -58,8 +58,9 @@ jobs:
               env:
                   MODULE: ${{ inputs.module }}
               run: |
-                  rm -rf saucebase/modules/$MODULE
-                  cp -r module-src saucebase/modules/$MODULE
+                  pkg=$(echo "$MODULE" | tr '[:upper:]' '[:lower:]')
+                  rm -rf saucebase/modules/$pkg
+                  cp -r module-src saucebase/modules/$pkg
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -102,11 +103,11 @@ jobs:
                   # Dependencies first (in declared order)
                   for dep in $DEPENDENCIES; do
                       pkg="${dep#saucebase/}"
-                      mod=$(echo "$pkg" | sed 's/-\([a-z]\)/\u\1/g; s/^\([a-z]\)/\u\1/')
-                      apply_patches "saucebase/modules/$mod/patches"
+                      apply_patches "saucebase/modules/$pkg/patches"
                   done
                   # Primary module last
-                  apply_patches "saucebase/modules/$MODULE/patches"
+                  mod=$(echo "$MODULE" | tr '[:upper:]' '[:lower:]')
+                  apply_patches "saucebase/modules/$mod/patches"
 
             - name: Install Composer dependencies
               working-directory: saucebase
@@ -124,7 +125,9 @@ jobs:
               working-directory: saucebase
               env:
                   MODULE: ${{ inputs.module }}
-              run: php artisan test modules/$MODULE/tests
+              run: |
+                  pkg=$(echo "$MODULE" | tr '[:upper:]' '[:lower:]')
+                  php artisan test modules/$pkg/tests
 
             - name: Archive saucebase environment
               run: tar --exclude='saucebase/node_modules' -czf saucebase-env.tar.gz saucebase/


### PR DESCRIPTION
This pull request updates the `test-module.yml` GitHub Actions workflow to consistently use lowercase module names instead of mixed or StudlyCase. The changes ensure that all file and directory operations, as well as test commands, reference modules in lowercase, improving reliability and consistency in automation.

**Workflow input and environment normalization:**

* Updated the `module` input description to clarify that module names should be provided in lowercase.
* All references to module directories now convert the `MODULE` variable to lowercase before use, ensuring consistent file path handling [[1]](diffhunk://#diff-6edc3e4912aeaaf0120b2601fcd211f0c00c0cbab77766b427fe35b14a92b561L61-R63) [[2]](diffhunk://#diff-6edc3e4912aeaaf0120b2601fcd211f0c00c0cbab77766b427fe35b14a92b561L127-R130).

**Patch application logic:**

* Updated dependency and primary module patch application to use lowercase paths, removing previous logic that attempted to convert names to StudlyCase.