### PR TITLE
Update Saucebase installer version and adjust Toaster theme binding

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,7 +2,8 @@
 version: '3'
 
 vars:
-  APP: ''
+  # Prefix for running commands in a containerized environment (e.g., 'docker compose exec app')
+  APP: '' 
 
 includes:
     # ── BEGIN MODULES ────────────────────────────────────────────────

--- a/composer.lock
+++ b/composer.lock
@@ -13240,16 +13240,16 @@
         },
         {
             "name": "saucebase/installer",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/saucebase-dev/installer.git",
-                "reference": "04206581a3ebf48b8779072076b0edf48f3df32c"
+                "reference": "0165bdc375fbfcf8659cfaad583b957c3ec5acc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/saucebase-dev/installer/zipball/04206581a3ebf48b8779072076b0edf48f3df32c",
-                "reference": "04206581a3ebf48b8779072076b0edf48f3df32c",
+                "url": "https://api.github.com/repos/saucebase-dev/installer/zipball/0165bdc375fbfcf8659cfaad583b957c3ec5acc4",
+                "reference": "0165bdc375fbfcf8659cfaad583b957c3ec5acc4",
                 "shasum": ""
             },
             "require": {
@@ -13285,9 +13285,9 @@
             "description": "Dev environment installer for Saucebase applications.",
             "support": {
                 "issues": "https://github.com/saucebase-dev/installer/issues",
-                "source": "https://github.com/saucebase-dev/installer/tree/v1.1.0"
+                "source": "https://github.com/saucebase-dev/installer/tree/v1.1.1"
             },
-            "time": "2026-06-19T19:33:39+00:00"
+            "time": "2026-06-19T19:39:32+00:00"
         },
         {
             "name": "saucebase/laravel-playwright",

--- a/resources/js/vue/components/ui/sonner/Wrapper.vue
+++ b/resources/js/vue/components/ui/sonner/Wrapper.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import Sonner from '@/components/ui/sonner/Sonner.vue';
 import type { Toast } from '@/types';
+import { useColorMode } from '@vueuse/core';
 import { router, usePage } from '@inertiajs/vue3';
-import { watch } from 'vue';
+import { computed, watch } from 'vue';
 import { toast } from 'vue-sonner';
 
 import 'vue-sonner/style.css';
+
+const colorMode = useColorMode({ storageKey: 'appearance' });
+const theme = computed((): 'dark' | 'light' => (colorMode.value === 'dark' ? 'dark' : 'light'));
 
 const page = usePage();
 
@@ -88,5 +92,5 @@ watch(
 );
 </script>
 <template>
-    <Sonner v-bind="$attrs" />
+    <Sonner :theme="theme" v-bind="$attrs" />
 </template>

--- a/resources/js/vue/components/ui/sonner/index.ts
+++ b/resources/js/vue/components/ui/sonner/index.ts
@@ -1,1 +1,1 @@
-export { default as Toaster } from './Sonner.vue';
+export { default as Toaster } from './Wrapper.vue';


### PR DESCRIPTION
This pull request updates the toast notification system to improve theming and usage. The main changes include switching the main export to a new `Wrapper.vue` component, which now handles theme selection (dark/light) based on the user's color mode preference, and ensures the `Sonner` component receives the correct theme.

**Toast Notification System Improvements:**

* Updated the main export in `index.ts` to use `Wrapper.vue` instead of `Sonner.vue`, centralizing toast logic and theming.
* Enhanced `Wrapper.vue` to detect and provide the current color mode (dark/light) using `@vueuse/core`'s `useColorMode`, and pass the theme to the `Sonner` component. [[1]](diffhunk://#diff-2a2a5d87d79b615620de63ece2d8d4c827c86201a758ac5ac9ab9614c42be68dR4-R13) [[2]](diffhunk://#diff-2a2a5d87d79b615620de63ece2d8d4c827c86201a758ac5ac9ab9614c42be68dL91-R95)

**Taskfile Documentation:**

* Added a comment in `Taskfile.yml` to clarify the purpose of the `APP` variable for containerized command prefixes.