### PR TITLE
docs: update installation instructions and CLI usage in AGENTS files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,15 +52,20 @@ docker compose logs -f nginx
 
 ### Installation & Setup
 
-```bash
-# Quick install (recommended for new projects)
-php artisan saucebase:install
+Installation is handled by the `saucebase` global Composer CLI, not an in-app artisan command:
 
-# Advanced options
-php artisan saucebase:install --no-docker    # Skip Docker setup
-php artisan saucebase:install --no-ssl       # Skip SSL generation
-php artisan saucebase:install --force        # Force reinstallation
-php artisan saucebase:install --no-interaction  # CI/CD mode
+```bash
+# New project — installs PHP/Composer if missing, scaffolds, and installs
+curl -fsSL https://install.saucebase.dev | bash
+
+# Or, with PHP/Composer already installed
+composer global require saucebase/installer
+saucebase new my-app
+
+# Re-run install against an existing checkout
+saucebase install --driver=docker --ssl=no
+saucebase install --driver=native --force
+saucebase install --driver=native --modules=none --force   # CI/CD mode
 ```
 
 ### Module Management

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Saucebase is a modular Laravel SaaS starter kit. Modules are installed via Composer and owned directly in the repository (copy-and-own).
 
-**Core message:** The foundation is built. Focus on your product. See [`docs/CLAUDE.md`](../docs/CLAUDE.md) → _Saucebase Philosophy_ for tone and value-proposition guidance.
+**Core message:** The foundation is built. Focus on your product. See the [Design Philosophy](https://saucebase-dev.github.io/docs/architecture/philosophy) doc for tone and value-proposition guidance.
 
 **Stack:** Laravel 13, PHP 8.4+, Vue 3 Composition API, TypeScript 5.8, Inertia.js 3, Tailwind CSS 4, Vite 6.4, Filament 5 admin panel, Docker (Nginx, MySQL 8, Redis, Mailpit)
 
@@ -45,9 +45,9 @@ composer remove saucebase/auth              # Removes module
 php artisan module:generate-types ModuleName   # single module
 php artisan module:generate-types              # all enabled modules
 
-# Framework selection (contributor dev workflow) — see Architecture > Frontend for gotchas
-php artisan saucebase:stack {vue|react} --dev    # Switch active framework in dev mode (keeps both dirs)
-php artisan saucebase:stack {vue|react} --reset  # Reset to clean state (removes frontend.json)
+# Framework selection (contributor dev workflow, via the global `saucebase` CLI) — see Architecture > Frontend for gotchas
+saucebase stack {vue|react} --dev    # Switch active framework in dev mode (keeps both dirs)
+saucebase stack {vue|react} --reset  # Reset to clean state (removes frontend.json)
 ```
 
 ## Architecture
@@ -89,7 +89,7 @@ Uses `internachi/modular`. Modules are Composer packages installed into `modules
 - `"dev": true` — contributor mode: both `vue/` and `react/` dirs kept, thin entry point passthroughs generated
 - `"dev"` absent — end-user install: selected framework flattened to `resources/js/`, other dir deleted (one-time)
 
-**`saucebase:stack` modes:**
+**`saucebase stack` modes:**
 - `--dev` — contributor workflow: copies config files, creates entry passthroughs, keeps both framework dirs
 - _(no flag)_ — end-user install: flattens one framework, deletes the other. Throws if `frontend.json` already exists
 - `--reset` — restores git-tracked files, removes `frontend.json`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The **recommended** way to install Saucebase is by running the command below:
 curl -fsSL https://install.saucebase.dev | bash
 ```
 
-The setup screen will guide you through choosing a frontend framework and installing your first modules.
+The CLI installs PHP/Composer if needed, then guides you through choosing a frontend framework and installing your first modules.
 
 Looking for help? Start with our [Getting Started](https://saucebase-dev.github.io/docs/) guide.
 


### PR DESCRIPTION
This pull request updates the installation and developer workflow documentation for Saucebase, shifting instructions to use the global `saucebase` CLI instead of in-app artisan commands. It also clarifies framework selection steps and updates references to core philosophy documentation.

**Installation & Setup Changes:**
* Updated installation instructions in `AGENTS.md` to use the global `saucebase` Composer CLI and installer script, removing references to `php artisan saucebase:install` and its options.
* Clarified in `README.md` that the installer script will install PHP/Composer if needed and guide the user through initial setup.

**Framework Selection Workflow:**
* Changed framework selection commands in `CLAUDE.md` to use the global `saucebase` CLI (`saucebase stack`) instead of artisan commands, and updated related documentation to match. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L48-R50) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L92-R92)

**Documentation & Philosophy References:**
* Updated the core message in `CLAUDE.md` to point to the new Design Philosophy documentation link.