### PR TITLE
ci: make the module E2E serve port configurable

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -13,6 +13,11 @@ on:
                 type: string
                 default: ''
                 description: 'Space-separated Composer packages, e.g. saucebase/auth'
+            serve_port:
+                required: false
+                type: string
+                default: '8000'
+                description: 'Port the E2E server listens on. Use 80 for modules whose URLs are host-based (subdomains), since a host derived from APP_URL drops the port.'
 
 jobs:
     detect-frameworks:
@@ -148,6 +153,11 @@ jobs:
             matrix:
                 framework: ${{ fromJSON(needs.detect-frameworks.outputs.matrix) }}
         name: E2E ${{ inputs.module }} (${{ matrix.framework }})
+        env:
+            SERVE_PORT: ${{ inputs.serve_port }}
+            # The non-empty branch must sit on `true`: '' is falsy in GitHub
+            # expressions, so `cond && '' || format(...)` always falls through.
+            APP_URL: http://localhost${{ inputs.serve_port != '80' && format(':{0}', inputs.serve_port) || '' }}
 
         steps:
             - name: Download environment artifact
@@ -182,20 +192,25 @@ jobs:
 
             - name: Start Laravel server
               working-directory: saucebase
-              run: php artisan serve --host=0.0.0.0 --port=8000 &
+              run: |
+                  # Ports below 1024 need root, and sudo drops the setup-php PATH.
+                  if [ "$SERVE_PORT" -lt 1024 ] && [ "$(id -u)" -ne 0 ]; then
+                      sudo -E env PATH="$PATH" php artisan serve --host=0.0.0.0 --port="$SERVE_PORT" &
+                  else
+                      php artisan serve --host=0.0.0.0 --port="$SERVE_PORT" &
+                  fi
 
             - name: Wait for server
               run: |
-                  timeout 30 bash -c 'until curl -f http://localhost:8000 > /dev/null 2>&1; do
-                    echo "Waiting for server..."
+                  timeout 30 bash -c "until curl -f ${APP_URL} > /dev/null 2>&1; do
+                    echo 'Waiting for server...'
                     sleep 2
-                  done'
+                  done"
                   echo "Server is ready!"
 
             - name: Run E2E tests
               working-directory: saucebase
               env:
-                  APP_URL: http://localhost:8000
                   MODULE: ${{ inputs.module }}
               run: npx playwright test modules/$MODULE/tests/e2e --max-failures=2
 

--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -193,12 +193,14 @@ jobs:
             - name: Start Laravel server
               working-directory: saucebase
               run: |
-                  # Ports below 1024 need root, and sudo drops the setup-php PATH.
+                  # Ports below 1024 are privileged by default. Lower the threshold
+                  # rather than serving as root, so the app never writes root-owned
+                  # logs, sessions, or SQLite files. Already root (act, containers)
+                  # can bind anything and may not have sysctl.
                   if [ "$SERVE_PORT" -lt 1024 ] && [ "$(id -u)" -ne 0 ]; then
-                      sudo -E env PATH="$PATH" php artisan serve --host=0.0.0.0 --port="$SERVE_PORT" &
-                  else
-                      php artisan serve --host=0.0.0.0 --port="$SERVE_PORT" &
+                      sudo sysctl -w "net.ipv4.ip_unprivileged_port_start=$SERVE_PORT"
                   fi
+                  php artisan serve --host=0.0.0.0 --port="$SERVE_PORT" &
 
             - name: Wait for server
               run: |


### PR DESCRIPTION
## Why

Modules whose E2E URLs are **host-based** rather than path-based cannot run on the default port.

A workspace host is derived as `<slug>.<central host>`, and the central host comes from `APP_URL` through `parse_url(..., PHP_URL_HOST)` — **which drops the port**. With `APP_URL=http://localhost:8000` the browser is sent to `http://acme.localhost/…` (port 80) while the server listens on 8000, so every host-based spec times out. Serving on 80 makes host and port agree; `*.localhost` resolves to loopback in Chromium.

The alternative — carrying the port in the stored domain — does not work: Spatie's `DomainTenantFinder` matches `$request->getHost()`, which strips ports, so it would need a custom finder plus changes to central-host matching. Not worth touching host-resolution logic to satisfy CI.

## What

One optional input, `serve_port` (default `'8000'`), used by the E2E job's server, wait loop, and `APP_URL`.

## Effect on existing modules: none

At the default `'8000'`:

- the input is additive — unset callers are unaffected;
- `APP_URL` evaluates to `http://localhost:8000`, the exact literal the E2E step already set;
- the `sudo` branch is unreachable (`8000 -lt 1024` is false);
- the wait loop curls the same URL as before.

The only difference is that `APP_URL` is exported at job level instead of on one step — same value. It is **not** written into `.env`, because a real environment variable already takes precedence over `.env` (`Illuminate\Support\Env` builds an `->immutable()` repository), so no step mutates application config.

The default stays `8000` deliberately: nothing was found that would break at 80, but keeping it means only the module that needs the new path exercises it, and the other six keep serving unprivileged. Flipping the default can be a one-line follow-up once port 80 is proven in real CI.

## Testing

CI-only change; the existing module workflows are the test. Merging this unblocks a follow-up in a module repo that passes `serve_port: '80'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test workflow configuration with an optional server port.
  * Added support for serving the application on privileged ports when required.
  * Updated readiness checks to use the configured application URL, including port 80 deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->