### PR TITLE
test: add test for root-relative branding URLs in GeneralSettings

### DIFF
--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -58,6 +58,8 @@ class GeneralSettings extends Settings
             return null;
         }
 
-        return Str::isUrl($path) ? $path : Storage::disk('public')->url($path);
+        return Str::startsWith($path, '/') || Str::isUrl($path)
+            ? $path
+            : Storage::disk('public')->url($path);
     }
 }

--- a/tests/Feature/GeneralSettingsTest.php
+++ b/tests/Feature/GeneralSettingsTest.php
@@ -235,6 +235,16 @@ class GeneralSettingsTest extends TestCase
                 ->where('settings.general.site_logo', 'https://cdn.example.com/logo.svg'));
     }
 
+    public function test_root_relative_branding_urls_are_not_resolved_as_storage_paths(): void
+    {
+        $settings = app(GeneralSettings::class);
+        $settings->site_icon = '/storage/tenant-logos/icon.png';
+        $settings->site_logo = '/storage/tenant-logos/logo.png';
+
+        $this->assertSame('/storage/tenant-logos/icon.png', $settings->siteIconUrl());
+        $this->assertSame('/storage/tenant-logos/logo.png', $settings->siteLogoUrl());
+    }
+
     public function test_frontend_stack_views_render_settings_driven_metadata(): void
     {
         foreach (['vue', 'react'] as $stack) {


### PR DESCRIPTION
This pull request updates how branding URLs are handled in the application settings, ensuring root-relative URLs are not incorrectly resolved as storage paths. It also adds a test to verify this behavior.

**Branding URL Handling:**

* Updated `publicFileUrl` in `GeneralSettings.php` to return the path as-is if it is root-relative (starts with `/`) or a full URL, instead of always resolving via the storage disk.

**Testing:**

* Added a test (`test_root_relative_branding_urls_are_not_resolved_as_storage_paths`) in `GeneralSettingsTest.php` to confirm that root-relative branding URLs are returned unchanged and not resolved as storage paths.