### PR TITLE
Add step to publish Filament assets in Laravel setup action

### DIFF
--- a/.github/actions/setup-laravel/action.yml
+++ b/.github/actions/setup-laravel/action.yml
@@ -108,6 +108,11 @@ runs:
           working-directory: ${{ inputs.working-directory }}
           run: php artisan key:generate
 
+        - name: Publish Filament assets
+          shell: bash
+          working-directory: ${{ inputs.working-directory }}
+          run: php artisan filament:assets
+
         - name: Run migrations
           shell: bash
           working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
This pull request adds a new step to the GitHub Actions workflow for Laravel projects. The new step ensures that Filament assets are published before running database migrations.

Workflow improvements:

* Added a `Publish Filament assets` step to the `.github/actions/setup-laravel/action.yml` workflow, which runs `php artisan filament:assets` to ensure Filament assets are available before migrations.