### PR TITLE
Enhance PageTransition component and update Vite config for path resolution

### DIFF
--- a/resources/js/react/components/PageTransition.tsx
+++ b/resources/js/react/components/PageTransition.tsx
@@ -13,7 +13,12 @@ export default function PageTransition({ children }: { children: ReactNode }) {
     pendingChildren.current = children;
 
     useEffect(() => {
-        if (page.url === prevUrl.current) return;
+        if (page.url === prevUrl.current) {
+            setDisplayedChildren(children);
+
+            return;
+        }
+
         prevUrl.current = page.url;
 
         const prefersReducedMotion =
@@ -31,7 +36,7 @@ export default function PageTransition({ children }: { children: ReactNode }) {
             setVisible(true);
         }, DURATION);
         return () => clearTimeout(t);
-    }, [page.url]);
+    }, [children, page.url]);
 
     return (
         <div

--- a/stubs/saucebase/stack/react/vite.config.js
+++ b/stubs/saucebase/stack/react/vite.config.js
@@ -75,11 +75,11 @@ function createConfig() {
         },
         resolve: {
             alias: {
-                '@': path.resolve(__dirname, 'resources/js/react'),
-                '@js': path.resolve(__dirname, 'resources/js'),
-                '@css': path.resolve(__dirname, 'resources/css'),
-                '@modules': path.resolve(__dirname, 'modules'),
-                'ziggy-js': path.resolve(__dirname, 'vendor/tightenco/ziggy'),
+                '@': path.resolve(import.meta.dirname, 'resources/js/react'),
+                '@js': path.resolve(import.meta.dirname, 'resources/js'),
+                '@css': path.resolve(import.meta.dirname, 'resources/css'),
+                '@modules': path.resolve(import.meta.dirname, 'modules'),
+                'ziggy-js': path.resolve(import.meta.dirname, 'vendor/tightenco/ziggy'),
             },
         },
     });

--- a/stubs/saucebase/stack/vue/vite.config.js
+++ b/stubs/saucebase/stack/vue/vite.config.js
@@ -88,11 +88,11 @@ async function createConfig() {
         },
         resolve: {
             alias: {
-                '@': path.resolve(__dirname, 'resources/js/vue'),
-                '@js': path.resolve(__dirname, 'resources/js'),
-                '@css': path.resolve(__dirname, 'resources/css'),
-                '@modules': path.resolve(__dirname, 'modules'),
-                'ziggy-js': path.resolve(__dirname, 'vendor/tightenco/ziggy'),
+                '@': path.resolve(import.meta.dirname, 'resources/js/vue'),
+                '@js': path.resolve(import.meta.dirname, 'resources/js'),
+                '@css': path.resolve(import.meta.dirname, 'resources/css'),
+                '@modules': path.resolve(import.meta.dirname, 'modules'),
+                'ziggy-js': path.resolve(import.meta.dirname, 'vendor/tightenco/ziggy'),
             },
         },
     });

--- a/tests/Support/ModuleSupport.php
+++ b/tests/Support/ModuleSupport.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Support;
+
+use InterNACHI\Modular\Support\ModuleRegistry;
+
+class ModuleSupport
+{
+    public static function has(string $name): bool
+    {
+        return app(ModuleRegistry::class)->module($name) !== null;
+    }
+}

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -66,11 +66,14 @@ async function currentAuthUser(page: Page): Promise<unknown> {
 // `expect.poll` rather than a single check: right after an in-page action
 // (e.g. clicking "log in") the redirect chain that follows — POST, then
 // possibly another server-side redirect from a module reacting to the new
-// session — may still be in flight, so the first reload can race it.
+// session — may still be in flight, so the first reload can race it. Each
+// attempt does a real network round trip (reload), not a cheap DOM check, so
+// the default 5s budget is tight under local multi-worker parallelism —
+// give it more room.
 export async function expectAuthenticated(page: Page): Promise<void> {
-    await expect.poll(() => currentAuthUser(page)).not.toBeNull();
+    await expect.poll(() => currentAuthUser(page), { timeout: 15_000 }).not.toBeNull();
 }
 
 export async function expectGuest(page: Page): Promise<void> {
-    await expect.poll(() => currentAuthUser(page)).toBeNull();
+    await expect.poll(() => currentAuthUser(page), { timeout: 15_000 }).toBeNull();
 }

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import type { Laravel } from '@saucebase/laravel-playwright';
 
 type SessionCookie = {
@@ -25,4 +25,52 @@ export async function loginAs(
             sameSite: 'Lax',
         },
     ]);
+}
+
+/**
+ * Checks authentication via the `auth.user` Inertia prop (shared globally by
+ * the auth module, and what the frontend itself reads — see
+ * `resources/js/vue/components/Header.vue`) rather than the post-login
+ * landing URL, which varies by which modules are installed (e.g. tenancy
+ * redirects authenticated visitors away from `/dashboard`).
+ *
+ * `/api/v1/user` looks like the obvious check but isn't wired for
+ * session-cookie auth in this app (`bootstrap/app.php` never registers
+ * Sanctum's `EnsureFrontendRequestsAreStateful`, so it only accepts bearer
+ * tokens) — it always 401s for a real browser session regardless of login
+ * state.
+ *
+ * A `reload()` is required before reading the prop: Inertia's client-side
+ * router updates its in-memory page state on navigation but does not rewrite
+ * the `<script data-page="app">` tag's contents, so reading it right after an
+ * in-page action (e.g. submitting the login form) would return stale,
+ * pre-navigation data. `waitForLoadState('networkidle')` has to come first:
+ * a login can trigger a whole chain of server-side redirects (e.g. tenancy
+ * funnelling into a workspace) driven by Inertia's client-side router, and
+ * reloading while that's still in flight reloads whatever URL the browser
+ * happens to be on that instant — which, called too early, is still the
+ * pre-login page.
+ */
+async function currentAuthUser(page: Page): Promise<unknown> {
+    await page.waitForLoadState('networkidle');
+    await page.reload();
+
+    return page.evaluate(() => {
+        const script = document.querySelector('script[data-page="app"]');
+        const data = script ? JSON.parse(script.textContent ?? '{}') : {};
+
+        return data?.props?.auth?.user ?? null;
+    });
+}
+
+// `expect.poll` rather than a single check: right after an in-page action
+// (e.g. clicking "log in") the redirect chain that follows — POST, then
+// possibly another server-side redirect from a module reacting to the new
+// session — may still be in flight, so the first reload can race it.
+export async function expectAuthenticated(page: Page): Promise<void> {
+    await expect.poll(() => currentAuthUser(page)).not.toBeNull();
+}
+
+export async function expectGuest(page: Page): Promise<void> {
+    await expect.poll(() => currentAuthUser(page)).toBeNull();
 }

--- a/tests/e2e/helpers/modules.ts
+++ b/tests/e2e/helpers/modules.ts
@@ -1,0 +1,16 @@
+import type { Laravel } from '@saucebase/laravel-playwright';
+
+/**
+ * Checks whether a module is installed in this checkout, mirroring the
+ * frontend's `modules().has(name)` convention for tests that need real
+ * module-owned UI (not just proof of authentication) and must skip when that
+ * UI belongs to a different combination of installed modules.
+ */
+export async function isModuleInstalled(
+    laravel: Laravel,
+    name: string,
+): Promise<boolean> {
+    return laravel.callFunction<boolean>('Tests\\Support\\ModuleSupport::has', [
+        name,
+    ]);
+}


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on enhanced test utilities, improved frontend module resolution, and bug fixes in page transitions. The most significant changes include new helpers for authentication and module detection in end-to-end tests, updates to Vite config alias resolution, and a fix for the page transition animation logic.

**E2E Test Utilities:**

* Added `expectAuthenticated` and `expectGuest` helpers in `tests/e2e/helpers/auth.ts` to reliably check authentication state using Inertia's `auth.user` prop, with robust handling for asynchronous navigation and redirects.
* Added `isModuleInstalled` helper in `tests/e2e/helpers/modules.ts` to determine if a backend module is installed, mirroring frontend module checks for more accurate test skipping.
* Introduced backend support class `ModuleSupport` in `tests/Support/ModuleSupport.php` to support module detection from Playwright tests.

**Frontend Configuration:**

* Updated Vite config files (`stubs/saucebase/stack/react/vite.config.js` and `stubs/saucebase/stack/vue/vite.config.js`) to use `import.meta.dirname` instead of `__dirname` for path resolution, improving compatibility with ESM and Vite. [[1]](diffhunk://#diff-00aa0dd36ae801c7b084b105852ea7c10f8c1f790fab149f491ea6ae43f8b403L78-R82) [[2]](diffhunk://#diff-2153ff1af6498375b4f4ed74347cbd56541ea391b743e36edc4d4930c82cd167L91-R95)

**Frontend Bug Fixes:**

* Fixed a bug in `PageTransition.tsx` where the displayed children were not updated if the URL didn't change, and ensured the effect hook responds to changes in `children` as well as `page.url`. [[1]](diffhunk://#diff-375c67daf38c25563744508062ab741c2564bb2124fc6fc6f487ae2e29f3bd82L16-R21) [[2]](diffhunk://#diff-375c67daf38c25563744508062ab741c2564bb2124fc6fc6f487ae2e29f3bd82L34-R39)